### PR TITLE
Updates to make targets, streamline instructions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,12 +4,15 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+"aws-lambda-powertools[all]" = "*"
 
 [dev-packages]
-cookiecutter = "*"
-pytest-cookies = "*"
+"aws-lambda-powertools[all]" = "*"
+boto3 = "*"
+boto3-stubs = "*"
 pytest = "*"
-flake8 = "*"
+pytest-cov = "*"
+pydantic = "*"
 
 [requires]
 python_version = "3.9"

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -23,7 +23,7 @@ install:
 dev:
 	$(info [*] Installing pipenv project dependencies)
 	@$(PIPENV) install
-	@$(PIPENV) install -d
+	@$(PIPENV) install --dev
 
 shell:
 	@$(PIPENV) shell
@@ -54,6 +54,11 @@ invoke-invalid-date-post-payment: ##=> Run SAM Local function with a given event
 
 invoke-missing-userid-post-payment: ##=> Run SAM Local function with a given event payload
 	@sam local invoke PostPaymentFunction --event events/invalid_missing_userid_post_payment.json
+
+generate-requirements: ##=> Populate requirements.txt file for each function based on Pipfile
+	$(info [*] Populating requirements.txt in src/get_balance and src/post_payment based on [packages] in Pipfile)
+	@$(PIPENV) requirements > src/get_balance/requirements.txt
+	@$(PIPENV) requirements > src/post_payment/requirements.txt
 
 run: ##=> Run SAM Local API GW and can optionally run new containers connected to a defined network
 	@test -z ${NETWORK} \
@@ -110,4 +115,28 @@ define HELP_MESSAGE
 
 	...::: Run SAM Local API Gateway within a Docker Network :::...
 	$ make run NETWORK="sam-network"
+
+	...::: Creates function requirements.txt from Pipfile :::...
+	$ make run generate-requirements
+
+	Invoke events locally:
+
+	...::: Run SAM Local Invoke with a Valid Balance Event :::...
+	$ make invoke-valid-get-balance
+
+	...::: Run SAM Local Invoke with a Valid Payment Event :::...
+	$ make invoke-valid-post-payment
+
+	...::: Run SAM Local Invoke with a Invalid Balance Event (missing user_id) :::...
+	$ make invoke-invalid-get-balance
+
+	...::: Run SAM Local Invoke with a Invalid Payment Event (invalid amount) :::...
+	$ make invoke-invalid-amount-post-payment
+
+	...::: Run SAM Local Invoke with a Invalid Payment Event (invalid date) :::...
+	$ make invoke-invalid-date-post-payment
+
+	...::: Run SAM Local Invoke with a Invalid Payment Event (missing user_id) :::...
+	$ make invoke-missing-userid-post-payment
+
 endef

--- a/{{cookiecutter.project_slug}}/README-TESTING.md
+++ b/{{cookiecutter.project_slug}}/README-TESTING.md
@@ -8,7 +8,7 @@ The code can be tested using the following code:
 make test
 ```
 
-**NOTE:** If you haven't run `pipenv install --dev` you're going to get some errors.
+**NOTE:** If you haven't already run `make install` you're going to get errors.
 
 ## What Is Being Tested?
 

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -12,8 +12,6 @@ The sample application uses the Serverless Application Model to build and deploy
 
 * [Python3.9](https://www.python.org/downloads/release/python-390/)
 
-* [Pipenv](https://pipenv.pypa.io/en/latest/)
-
 * Optional: [Docker Desktop](https://www.docker.com/products/docker-desktop/) if deploying and testing locally
 
 ## Installing Python Dependencies
@@ -21,7 +19,7 @@ The sample application uses the Serverless Application Model to build and deploy
 The local testing environment makes use of dependencies in the project's [Pipfile](./Pipfile). These dependencies need to be installed by running the following command:
 
 ```bash
-pipenv install --dev
+make install
 ```
 
 ## What's Next?


### PR DESCRIPTION
Updating the Makefile and accompanying targets to make generative requirements based on the `Pipefile` possible. Also added targets for testing events locally to the help section of the `Makefile`.